### PR TITLE
Update build for developer guides

### DIFF
--- a/_IGNORE/cp_common_docs.sh
+++ b/_IGNORE/cp_common_docs.sh
@@ -50,6 +50,24 @@ mkdir -p i18n/ja/docusaurus-plugin-content-docs/version-3.1/developers/
 mkdir -p i18n/ja/docusaurus-plugin-content-docs/version-2.5/developers/
 
 
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/ja/docusaurus-plugin-content-docs/version-3.5/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/ja/docusaurus-plugin-content-docs/version-3.4/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/ja/docusaurus-plugin-content-docs/version-3.3/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/ja/docusaurus-plugin-content-docs/version-3.2/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/ja/docusaurus-plugin-content-docs/version-3.1/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/ja/docusaurus-plugin-content-docs/version-2.5/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png versioned_docs/version-3.4/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png versioned_docs/version-3.3/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png versioned_docs/version-3.2/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png versioned_docs/version-3.1/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png versioned_docs/version-2.5/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/zh/docusaurus-plugin-content-docs/version-3.5/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/zh/docusaurus-plugin-content-docs/version-3.4/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/zh/docusaurus-plugin-content-docs/version-3.3/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/zh/docusaurus-plugin-content-docs/version-3.2/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/zh/docusaurus-plugin-content-docs/version-3.1/_assets/
+cp versioned_docs/version-3.5/_assets/visualized_heap_profile.png i18n/zh/docusaurus-plugin-content-docs/version-2.5/_assets/
+
 cp versioned_docs/version-3.5/_assets/debug_info.png i18n/ja/docusaurus-plugin-content-docs/version-3.5/_assets/
 cp versioned_docs/version-3.5/_assets/debug_info.png i18n/ja/docusaurus-plugin-content-docs/version-3.4/_assets/
 cp versioned_docs/version-3.5/_assets/debug_info.png i18n/ja/docusaurus-plugin-content-docs/version-3.3/_assets/
@@ -163,3 +181,12 @@ cp -r i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/ja/do
 cp -r i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/ja/docusaurus-plugin-content-docs/version-3.1/developers/
 cp -r i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/ja/docusaurus-plugin-content-docs/version-2.5/developers/
 
+rm versioned_docs/version-3.2/developers/versions.md
+rm versioned_docs/version-3.1/developers/versions.md
+rm versioned_docs/version-2.5/developers/versions.md
+rm i18n/zh/docusaurus-plugin-content-docs/version-3.2/developers/versions.md
+rm i18n/zh/docusaurus-plugin-content-docs/version-3.1/developers/versions.md
+rm i18n/zh/docusaurus-plugin-content-docs/version-2.5/developers/versions.md
+rm i18n/ja/docusaurus-plugin-content-docs/version-3.2/developers/versions.md
+rm i18n/ja/docusaurus-plugin-content-docs/version-3.1/developers/versions.md
+rm i18n/ja/docusaurus-plugin-content-docs/version-2.5/developers/versions.md

--- a/_IGNORE/cp_common_docs.sh
+++ b/_IGNORE/cp_common_docs.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+rm -rf versioned_docs/version-*/release_notes versioned_docs/version-*/developers
+rm -rf i18n/zh/docusaurus-plugin-content-docs/version-*/release_notes i18n/zh/docusaurus-plugin-content-docs/version-*/developers
+rm -rf i18n/ja/docusaurus-plugin-content-docs/version-*/release_notes i18n/ja/docusaurus-plugin-content-docs/version-*/developers
+
 mkdir -p releasenotes
 mkdir -p common
 
@@ -45,9 +49,6 @@ mkdir -p i18n/ja/docusaurus-plugin-content-docs/version-3.2/developers/
 mkdir -p i18n/ja/docusaurus-plugin-content-docs/version-3.1/developers/
 mkdir -p i18n/ja/docusaurus-plugin-content-docs/version-2.5/developers/
 
-rm -rf versioned_docs/version-*/release_notes versioned_docs/version-*/developers
-rm -rf i18n/zh/docusaurus-plugin-content-docs/version-*/release_notes i18n/zh/docusaurus-plugin-content-docs/version-*/developers
-rm -rf i18n/ja/docusaurus-plugin-content-docs/version-*/release_notes i18n/ja/docusaurus-plugin-content-docs/version-*/developers
 
 cp versioned_docs/version-3.5/_assets/debug_info.png i18n/ja/docusaurus-plugin-content-docs/version-3.5/_assets/
 cp versioned_docs/version-3.5/_assets/debug_info.png i18n/ja/docusaurus-plugin-content-docs/version-3.4/_assets/

--- a/_IGNORE/cp_common_docs.sh
+++ b/_IGNORE/cp_common_docs.sh
@@ -120,116 +120,45 @@ mv common/releasenotes/ja/*or.md i18n/ja/docusaurus-plugin-content-docs-releasen
 cp -r common/releasenotes/en-us/build-starrocks versioned_docs/version-3.5/developers/
 cp -r common/releasenotes/en-us/code-style-guides versioned_docs/version-3.5/developers/
 cp common/releasenotes/en-us/debuginfo.md versioned_docs/version-3.5/developers/
-cp common/releasenotes/en-us/versions.md versioned_docs/version-3.5/developers/
 cp -r common/releasenotes/en-us/development-environment versioned_docs/version-3.5/developers/
+cp common/releasenotes/en-us/How_to_Contribute.md versioned_docs/version-3.5/developers/
+cp common/releasenotes/en-us/jemalloc_heap_profile.md versioned_docs/version-3.5/developers/
 cp -r common/releasenotes/en-us/trace-tools versioned_docs/version-3.5/developers/
+cp common/releasenotes/en-us/versions.md versioned_docs/version-3.5/developers/
 
-cp -r common/releasenotes/en-us/build-starrocks versioned_docs/version-3.4/developers/
-cp -r common/releasenotes/en-us/code-style-guides versioned_docs/version-3.4/developers/
-cp common/releasenotes/en-us/debuginfo.md versioned_docs/version-3.4/developers/
-cp common/releasenotes/en-us/versions.md versioned_docs/version-3.4/developers/
-cp -r common/releasenotes/en-us/development-environment versioned_docs/version-3.4/developers/
-cp -r common/releasenotes/en-us/trace-tools versioned_docs/version-3.4/developers/
+cp -r versioned_docs/version-3.5/developers/* versioned_docs/version-3.4/developers/
+cp -r versioned_docs/version-3.5/developers/* versioned_docs/version-3.3/developers/
+cp -r versioned_docs/version-3.5/developers/* versioned_docs/version-3.2/developers/
+cp -r versioned_docs/version-3.5/developers/* versioned_docs/version-3.1/developers/
+cp -r versioned_docs/version-3.5/developers/* versioned_docs/version-2.5/developers/
 
-cp -r common/releasenotes/en-us/build-starrocks versioned_docs/version-3.3/developers/
-cp -r common/releasenotes/en-us/code-style-guides versioned_docs/version-3.3/developers/
-cp common/releasenotes/en-us/debuginfo.md versioned_docs/version-3.3/developers/
-cp common/releasenotes/en-us/versions.md versioned_docs/version-3.3/developers/
-cp -r common/releasenotes/en-us/development-environment versioned_docs/version-3.3/developers/
-cp -r common/releasenotes/en-us/trace-tools versioned_docs/version-3.3/developers/
-
-cp -r common/releasenotes/en-us/build-starrocks versioned_docs/version-3.2/developers/
-cp -r common/releasenotes/en-us/code-style-guides versioned_docs/version-3.2/developers/
-cp common/releasenotes/en-us/debuginfo.md versioned_docs/version-3.2/developers/
-cp -r common/releasenotes/en-us/development-environment versioned_docs/version-3.2/developers/
-cp -r common/releasenotes/en-us/trace-tools versioned_docs/version-3.2/developers/
-
-cp -r common/releasenotes/en-us/build-starrocks versioned_docs/version-3.1/developers/
-cp -r common/releasenotes/en-us/code-style-guides versioned_docs/version-3.1/developers/
-cp common/releasenotes/en-us/debuginfo.md versioned_docs/version-3.1/developers/
-cp -r common/releasenotes/en-us/development-environment versioned_docs/version-3.1/developers/
-cp -r common/releasenotes/en-us/trace-tools versioned_docs/version-3.1/developers/
-
-cp -r common/releasenotes/zh-cn/build-starrocks i18n/zh/docusaurus-plugin-content-docs/version-3.1/developers/
-cp -r common/releasenotes/zh-cn/code-style-guides i18n/zh/docusaurus-plugin-content-docs/version-3.1/developers/
-cp common/releasenotes/zh-cn/debuginfo.md i18n/zh/docusaurus-plugin-content-docs/version-3.1/developers/
-cp -r common/releasenotes/zh-cn/development-environment i18n/zh/docusaurus-plugin-content-docs/version-3.1/developers/
-cp -r common/releasenotes/zh-cn/trace-tools i18n/zh/docusaurus-plugin-content-docs/version-3.1/developers/
-
-cp -r common/releasenotes/zh-cn/build-starrocks i18n/zh/docusaurus-plugin-content-docs/version-3.2/developers/
-cp -r common/releasenotes/zh-cn/code-style-guides i18n/zh/docusaurus-plugin-content-docs/version-3.2/developers/
-cp common/releasenotes/zh-cn/debuginfo.md i18n/zh/docusaurus-plugin-content-docs/version-3.2/developers/
-cp -r common/releasenotes/zh-cn/development-environment i18n/zh/docusaurus-plugin-content-docs/version-3.2/developers/
-cp -r common/releasenotes/zh-cn/trace-tools i18n/zh/docusaurus-plugin-content-docs/version-3.2/developers/
-
-cp -r common/releasenotes/zh-cn/build-starrocks i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
-cp -r common/releasenotes/zh-cn/code-style-guides i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
-cp common/releasenotes/zh-cn/debuginfo.md i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
-cp common/releasenotes/zh-cn/versions.md i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
+cp -r common/releasenotes/zh-cn/build-starrocks         i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
+cp -r common/releasenotes/zh-cn/code-style-guides       i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
+cp common/releasenotes/zh-cn/debuginfo.md               i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
 cp -r common/releasenotes/zh-cn/development-environment i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
-cp -r common/releasenotes/zh-cn/trace-tools i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
+cp common/releasenotes/zh-cn/How_to_Contribute.md       i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
+cp common/releasenotes/zh-cn/jemalloc_heap_profile.md   i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
+cp -r common/releasenotes/zh-cn/trace-tools             i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
+cp common/releasenotes/zh-cn/versions.md                i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/
 
-cp -r common/releasenotes/zh-cn/build-starrocks i18n/zh/docusaurus-plugin-content-docs/version-3.4/developers/
-cp -r common/releasenotes/zh-cn/code-style-guides i18n/zh/docusaurus-plugin-content-docs/version-3.4/developers/
-cp common/releasenotes/zh-cn/debuginfo.md i18n/zh/docusaurus-plugin-content-docs/version-3.4/developers/
-cp common/releasenotes/zh-cn/versions.md i18n/zh/docusaurus-plugin-content-docs/version-3.4/developers/
-cp -r common/releasenotes/zh-cn/development-environment i18n/zh/docusaurus-plugin-content-docs/version-3.4/developers/
-cp -r common/releasenotes/zh-cn/trace-tools i18n/zh/docusaurus-plugin-content-docs/version-3.4/developers/
+cp -r i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/zh/docusaurus-plugin-content-docs/version-3.4/developers/
+cp -r i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/zh/docusaurus-plugin-content-docs/version-3.3/developers/
+cp -r i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/zh/docusaurus-plugin-content-docs/version-3.2/developers/
+cp -r i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/zh/docusaurus-plugin-content-docs/version-3.1/developers/
+cp -r i18n/zh/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/zh/docusaurus-plugin-content-docs/version-2.5/developers/
 
-cp -r common/releasenotes/zh-cn/build-starrocks i18n/zh/docusaurus-plugin-content-docs/version-3.3/developers/
-cp -r common/releasenotes/zh-cn/code-style-guides i18n/zh/docusaurus-plugin-content-docs/version-3.3/developers/
-cp common/releasenotes/zh-cn/debuginfo.md i18n/zh/docusaurus-plugin-content-docs/version-3.3/developers/
-cp common/releasenotes/zh-cn/versions.md i18n/zh/docusaurus-plugin-content-docs/version-3.3/developers/
-cp -r common/releasenotes/zh-cn/development-environment i18n/zh/docusaurus-plugin-content-docs/version-3.3/developers/
-cp -r common/releasenotes/zh-cn/trace-tools i18n/zh/docusaurus-plugin-content-docs/version-3.3/developers/
-
-cp -r common/releasenotes/ja/build-starrocks i18n/ja/docusaurus-plugin-content-docs/version-3.1/developers/
-cp -r common/releasenotes/ja/code-style-guides i18n/ja/docusaurus-plugin-content-docs/version-3.1/developers/
-cp common/releasenotes/ja/debuginfo.md i18n/ja/docusaurus-plugin-content-docs/version-3.1/developers/
-cp -r common/releasenotes/ja/development-environment i18n/ja/docusaurus-plugin-content-docs/version-3.1/developers/
-cp -r common/releasenotes/ja/trace-tools i18n/ja/docusaurus-plugin-content-docs/version-3.1/developers/
-
-cp -r common/releasenotes/ja/build-starrocks i18n/ja/docusaurus-plugin-content-docs/version-3.2/developers/
-cp -r common/releasenotes/ja/code-style-guides i18n/ja/docusaurus-plugin-content-docs/version-3.2/developers/
-cp common/releasenotes/ja/debuginfo.md i18n/ja/docusaurus-plugin-content-docs/version-3.2/developers/
-cp -r common/releasenotes/ja/development-environment i18n/ja/docusaurus-plugin-content-docs/version-3.2/developers/
-cp -r common/releasenotes/ja/trace-tools i18n/ja/docusaurus-plugin-content-docs/version-3.2/developers/
-
-cp -r common/releasenotes/ja/build-starrocks i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
-cp -r common/releasenotes/ja/code-style-guides i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
-cp common/releasenotes/ja/debuginfo.md i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
-cp common/releasenotes/ja/versions.md i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
+cp -r common/releasenotes/ja/build-starrocks         i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
+cp -r common/releasenotes/ja/code-style-guides       i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
+cp common/releasenotes/ja/debuginfo.md               i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
 cp -r common/releasenotes/ja/development-environment i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
-cp -r common/releasenotes/ja/trace-tools i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
+cp common/releasenotes/ja/How_to_Contribute.md       i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
+cp common/releasenotes/ja/jemalloc_heap_profile.md   i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
+cp -r common/releasenotes/ja/trace-tools             i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
+cp common/releasenotes/ja/versions.md                i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/
 
-cp -r common/releasenotes/ja/build-starrocks i18n/ja/docusaurus-plugin-content-docs/version-3.4/developers/
-cp -r common/releasenotes/ja/code-style-guides i18n/ja/docusaurus-plugin-content-docs/version-3.4/developers/
-cp common/releasenotes/ja/debuginfo.md i18n/ja/docusaurus-plugin-content-docs/version-3.4/developers/
-cp common/releasenotes/ja/versions.md i18n/ja/docusaurus-plugin-content-docs/version-3.4/developers/
-cp -r common/releasenotes/ja/development-environment i18n/ja/docusaurus-plugin-content-docs/version-3.4/developers/
-cp -r common/releasenotes/ja/trace-tools i18n/ja/docusaurus-plugin-content-docs/version-3.4/developers/
+cp -r i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/ja/docusaurus-plugin-content-docs/version-3.4/developers/
+cp -r i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/ja/docusaurus-plugin-content-docs/version-3.3/developers/
+cp -r i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/ja/docusaurus-plugin-content-docs/version-3.2/developers/
+cp -r i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/ja/docusaurus-plugin-content-docs/version-3.1/developers/
+cp -r i18n/ja/docusaurus-plugin-content-docs/version-3.5/developers/* i18n/ja/docusaurus-plugin-content-docs/version-2.5/developers/
 
-cp -r common/releasenotes/ja/build-starrocks i18n/ja/docusaurus-plugin-content-docs/version-3.3/developers/
-cp -r common/releasenotes/ja/code-style-guides i18n/ja/docusaurus-plugin-content-docs/version-3.3/developers/
-cp common/releasenotes/ja/debuginfo.md i18n/ja/docusaurus-plugin-content-docs/version-3.3/developers/
-cp common/releasenotes/ja/versions.md i18n/ja/docusaurus-plugin-content-docs/version-3.3/developers/
-cp -r common/releasenotes/ja/development-environment i18n/ja/docusaurus-plugin-content-docs/version-3.3/developers/
-cp -r common/releasenotes/ja/trace-tools i18n/ja/docusaurus-plugin-content-docs/version-3.3/developers/
-
-cp -r common/releasenotes/en-us/build-starrocks versioned_docs/version-2.5/developers/
-cp -r common/releasenotes/en-us/code-style-guides versioned_docs/version-2.5/developers/
-cp common/releasenotes/en-us/debuginfo.md versioned_docs/version-2.5/developers/
-cp -r common/releasenotes/en-us/development-environment versioned_docs/version-2.5/developers/
-cp -r common/releasenotes/en-us/trace-tools versioned_docs/version-2.5/developers/
-
-cp -r common/releasenotes/zh-cn/build-starrocks i18n/zh/docusaurus-plugin-content-docs/version-2.5/developers/
-cp -r common/releasenotes/zh-cn/code-style-guides i18n/zh/docusaurus-plugin-content-docs/version-2.5/developers/
-cp common/releasenotes/zh-cn/debuginfo.md i18n/zh/docusaurus-plugin-content-docs/version-2.5/developers/
-cp -r common/releasenotes/zh-cn/development-environment i18n/zh/docusaurus-plugin-content-docs/version-2.5/developers/
-cp -r common/releasenotes/zh-cn/trace-tools i18n/zh/docusaurus-plugin-content-docs/version-2.5/developers/
-
-cp -r common/releasenotes/ja/build-starrocks i18n/ja/docusaurus-plugin-content-docs/version-2.5/developers/
-cp -r common/releasenotes/ja/code-style-guides i18n/ja/docusaurus-plugin-content-docs/version-2.5/developers/
-cp common/releasenotes/ja/debuginfo.md i18n/ja/docusaurus-plugin-content-docs/version-2.5/developers/
-cp -r common/releasenotes/ja/development-environment i18n/ja/docusaurus-plugin-content-docs/version-2.5/developers/
-cp -r common/releasenotes/ja/trace-tools i18n/ja/docusaurus-plugin-content-docs/version-2.5/developers/


### PR DESCRIPTION
Copies all of the developer docs from `main` to the versioned directories. This is similar to what we do with release notes, as neither release notes nor developer docs have been getting backported.

Some files are deleted from unmaintained versions (2.5 - 3.2) as we cannot backport to them, so they do not have the version information. 