### PR TITLE
allow only latest Japanese version to be indexed by Google

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,9 +1,14 @@
 
 User-agent: *
+Disallow: /docs/4.*/
 Disallow: /docs/3.*/
 Disallow: /docs/2.5/
+Disallow: /zh/docs/4.*/
 Disallow: /zh/docs/3.*/
 Disallow: /zh/docs/2.5/
+Disallow: /ja/docs/4.*/
+Disallow: /ja/docs/3.*/
+Disallow: /ja/docs/2.5/
 
 User-agent: Googlebot
 Disallow: /zh/


### PR DESCRIPTION
Goals:
- only index the latest English and Japanese docs

changes
- add rules to disallow the future `/4.*/` dirs
- add rules to disallow all Japanese dirs other than latest