### PR TITLE
[Doc] preliminary check to make sure settings are documented

### DIFF
--- a/checksettings/.gitignore
+++ b/checksettings/.gitignore
@@ -1,0 +1,5 @@
+badlist
+output
+script
+variables
+variables.txt

--- a/checksettings/README.md
+++ b/checksettings/README.md
@@ -1,0 +1,10 @@
+# Check the docs for missing settings
+
+The script `get_settings.sh`:
+
+1. connects to a running StarRocks DB and writes the list of settings to a file `variables.txt` using `SHOW VARIABLES`
+1. Reads `variables.txt` line by line and:
+   1. Throws away the first line of the `variables.txt` as it is the word "variables"
+   1. Checks the Markdown file `System_variable.md` for every subsequent variable name 
+   1. Uses the Algolia search API to check the docs for any variables not in `System_variable.md` and reports if the variable is found in the docs anywhere.
+

--- a/checksettings/algoliacheck.sh
+++ b/checksettings/algoliacheck.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+APP_ID="ER08SJMRY1"
+API_KEY="92292046d551109a1f2c463f1338c39b"
+SEARCH_STRING=$1
+INDEX_NAME="starrocks"
+
+# Make the request
+RESPONSE=$(curl -s -X POST \
+  -H "X-Algolia-Application-Id: $APP_ID" \
+  -H "X-Algolia-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  --data "{
+    \"query\": \"$SEARCH_STRING\",
+    \"facetFilters\": [[\"docusaurus_tag:docs-default-4.0\"]]
+  }" \
+  "https://${APP_ID}-dsn.algolia.net/1/indexes/${INDEX_NAME}/query")
+
+# Parse results using jq
+URLS=$(echo "$RESPONSE" | jq -r '.hits[].url')
+
+if [ -z "$URLS" ]; then
+  echo "No results found in Algolia '$SEARCH_STRING'"
+else
+  echo "Found results in Algolia '$SEARCH_STRING' at:"
+  echo "$URLS"
+fi
+

--- a/checksettings/get_settings.sh
+++ b/checksettings/get_settings.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+mysql -P9030 -h 127.0.0.1 -u root <script >variables.txt
+{
+    read
+    while IFS=$'\t' read -r first_field rest_of_line; do
+        if grep -q "\#\#\# $first_field" /Users/droscign/GitHub/starrocks/docs/en/sql-reference/System_variable.md; then
+            : # do nothing
+        else
+            echo "Setting: $first_field"
+            echo "NOT in System_variable.md, checking Algolia"
+            ./algoliacheck.sh $first_field
+            echo "-----------------------------------------"
+        fi
+        #grep "\#\#\# $first_field" /Users/droscign/GitHub/starrocks/docs/en/sql-reference/System_variable.md| grep -v ":0"
+        # Add your action here using $first_field
+    done
+} <variables.txt


### PR DESCRIPTION
## Prerequisites: 
- running StarRocks system (I use [Docker compose](https://github.com/StarRocks/demo/blob/master/deploy/docker-compose/docker-compose.yml))
- MySQL client 8.0 (I use `brew install mysql-client@8.0`)

## Overview

The script `get_settings.sh`:

1. connects to a running StarRocks DB and writes the list of settings to a file `variables.txt` using `SHOW VARIABLES`
1. Reads `variables.txt` line by line and:
   1. Throws away the first line of the `variables.txt` as it is the word "variables"
   1. Checks the Markdown file `System_variable.md` for every subsequent variable name 
   1. Uses the Algolia search API to check the docs for any variables not in `System_variable.md` and reports if the variable is found in the docs anywhere.

## To Do

- Identify which files to check, probably it is:
   - System_variable.md
   - BE_configuration.md
   - FE_configuration.md 
- Check English, Chinese, and Japanese versions of the file(s) instead of only English and only System_variable.md
- Figure out why aliases are not detected properly, for example `transaction_isolation` is an alias for `tx_isolation` and both terms are on the System_variable.md page, but the script reports an issue.
- More to do's will be apparent after the above

## Sample output

```sh
-----------------------------------------
Setting: query_cache_hot_partition_num
NOT in System_variable.md, checking Algolia
No results found in Algolia 'query_cache_hot_partition_num'
-----------------------------------------
Setting: query_delivery_timeout
NOT in System_variable.md, checking Algolia
No results found in Algolia 'query_delivery_timeout'
-----------------------------------------
Setting: query_history_keep_seconds
NOT in System_variable.md, checking Algolia
No results found in Algolia 'query_history_keep_seconds'
-----------------------------------------
Setting: query_history_load_interval_seconds
NOT in System_variable.md, checking Algolia
No results found in Algolia 'query_history_load_interval_seconds'
-----------------------------------------
Setting: query_queue_driver_high_water
NOT in System_variable.md, checking Algolia
Found results in Algolia 'query_queue_driver_high_water' at:
https://docs.starrocks.io/zh/docs/administration/management/resource_management/query_queues/#%E6%A0%B9%E6%8D%AE%E6%9F%A5%E8%AF%A2%E5%B9%B6%E5%8F%91%E6%95%B0%E9%87%8F%E5%8A%A8%E6%80%81%E8%B0%83%E6%95%B4%E6%9F%A5%E8%AF%A2%E5%B9%B6%E5%8F%91%E5%BA%A6
https://docs.starrocks.io/ja/docs/administration/management/resource_management/query_queues/#configure-dynamic-adjustment-of-query-concurrency
https://docs.starrocks.io/docs/administration/management/resource_management/query_queues/#configure-dynamic-adjustment-of-query-concurrency
-----------------------------------------
Setting: query_queue_driver_low_water
NOT in System_variable.md, checking Algolia
Found results in Algolia 'query_queue_driver_low_water' at:
https://docs.starrocks.io/zh/docs/administration/management/resource_management/query_queues/#%E6%A0%B9%E6%8D%AE%E6%9F%A5%E8%AF%A2%E5%B9%B6%E5%8F%91%E6%95%B0%E9%87%8F%E5%8A%A8%E6%80%81%E8%B0%83%E6%95%B4%E6%9F%A5%E8%AF%A2%E5%B9%B6%E5%8F%91%E5%BA%A6
https://docs.starrocks.io/ja/docs/administration/management/resource_management/query_queues/#configure-dynamic-adjustment-of-query-concurrency
https://docs.starrocks.io/docs/administration/management/resource_management/query_queues/#configure-dynamic-adjustment-of-query-concurrency
-----------------------------------------
Setting: query_queue_fresh_resource_usage_interval_ms
NOT in System_variable.md, checking Algolia
Found results in Algolia 'query_queue_fresh_resource_usage_interval_ms' at:
https://docs.starrocks.io/docs/sql-reference/System_variable/#set-variables-globally-or-for-a-single-session
https://docs.starrocks.io/zh/docs/sql-reference/System_variable/#%E8%AE%BE%E7%BD%AE%E5%8F%98%E9%87%8F%E5%85%A8%E5%B1%80%E7%94%9F%E6%95%88%E6%88%96%E5%9C%A8%E4%BC%9A%E8%AF%9D%E4%B8%AD%E7%94%9F%E6%95%88
https://docs.starrocks.io/ja/docs/sql-reference/System_variable/#%E5%A4%89%E6%95%B0%E3%82%92%E3%82%B0%E3%83%AD%E3%83%BC%E3%83%90%E3%83%AB%E3%81%BE%E3%81%9F%E3%81%AF%E5%8D%98%E4%B8%80%E3%81%AE%E3%82%BB%E3%83%83%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%A7%E8%A8%AD%E5%AE%9A
-----------------------------------------
Setting: resource_group
NOT in System_variable.md, checking Algolia
Found results in Algolia 'resource_group' at:
https://docs.starrocks.io/zh/docs/administration/management/monitoring/metrics/#resource_group_scan_use_ratio%E5%B7%B2%E5%BC%83%E7%94%A8
```