### PR TITLE
Improve agent-friendly-docs (afdocs.dev) score

### DIFF
--- a/.github/workflows/prod_deploy_docusaurus.yml
+++ b/.github/workflows/prod_deploy_docusaurus.yml
@@ -64,11 +64,19 @@ jobs:
           export BROWSERSLIST_IGNORE_OLD_DATA=true
           yarn build
 
+      - name: Post-process llms.txt and markdown for agents
+        run: node scripts/llms-postprocess.js build
+
       - name: sync to S3
         env:
           BUCKET_SECRET: ${{ secrets.AWS_OSS_DOCS_PROD_BUCKET }}
         run: |
           aws s3 sync build/ s3://$BUCKET_SECRET/ --quiet --delete $*
+          # Serve Markdown twins as text/markdown so agents (and content
+          # negotiation) get a readable response body, not a file download.
+          aws s3 cp build/ s3://$BUCKET_SECRET/ --quiet --recursive \
+            --exclude "*" --include "*.md" \
+            --content-type "text/markdown; charset=utf-8"
 
       - name: clean cdn cache
         env:

--- a/.github/workflows/stage_deploy_docusaurus.yml
+++ b/.github/workflows/stage_deploy_docusaurus.yml
@@ -76,11 +76,21 @@ jobs:
           fi
           yarn build
 
+      - name: Post-process llms.txt and markdown for agents
+        env:
+          SITE_URL: https://docs-stage.starrocks.io
+        run: node scripts/llms-postprocess.js build
+
       - name: sync to S3
         env:
           BUCKET_SECRET: ${{ secrets.AWS_OSS_DOCS_STAGE_BUCKET }}
         run: |
           aws s3 sync build/ s3://$BUCKET_SECRET/ --quiet --delete $*
+          # Serve Markdown twins as text/markdown so agents (and content
+          # negotiation) get a readable response body, not a file download.
+          aws s3 cp build/ s3://$BUCKET_SECRET/ --quiet --recursive \
+            --exclude "*" --include "*.md" \
+            --content-type "text/markdown; charset=utf-8"
 
       - name: clean cdn cache
         env:

--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,8 @@ export DOCUSAURUS_IGNORE_SSG_WARNINGS=true
 export NODE_OPTIONS="--max-old-space-size=12288"
 export DOCUSAURUS_SSR_CONCURRENCY=2
 export DOCUSAURUS_PERF_LOGGER=false
-yarn clear && yarn build && yarn serve
+yarn clear && yarn build
+# Agent-friendly docs: prepend markdown directives + split llms.txt into a
+# root index and per-section files. Must run AFTER the build completes.
+node scripts/llms-postprocess.js build
+yarn serve

--- a/cloudfront/README.md
+++ b/cloudfront/README.md
@@ -1,0 +1,147 @@
+# CloudFront changes for agent-friendly docs
+
+Two of the [afdocs.dev](https://afdocs.dev/) checks can only be fixed at the CDN
+layer — they are not part of the Docusaurus build. These steps apply to the
+**production** CloudFront distribution in front of the `docs.starrocks.io` S3
+bucket (`us-west-2`). Apply the same to the staging distribution when ready.
+
+> You need AWS Console or CLI access to the CloudFront distribution. Nothing
+> here changes the S3 bucket contents — the `.md` files are already uploaded by
+> the normal `aws s3 sync build/` step.
+
+There are two independent fixes:
+
+1. **Content negotiation** (`Accept: text/markdown`) — a CloudFront Function.
+2. **Real 404s** (stop the soft-404 that returns HTTP 200 for missing pages) — a
+   custom error response.
+
+---
+
+## 1. Content negotiation — CloudFront Function
+
+**What it fixes:** the `content-negotiation` check. Agents (Claude Code, Cursor,
+OpenCode) request `Accept: text/markdown`; today CloudFront ignores it and
+returns HTML. The function below rewrites the request to the page's `.md` twin.
+
+Source: [`viewer-request-markdown.js`](./viewer-request-markdown.js)
+
+### Apply via Console
+
+1. CloudFront → **Functions** → **Create function**.
+   - Name: `docs-markdown-content-negotiation`
+   - Runtime: **cloudfront-js-2.0**
+2. Paste the contents of `viewer-request-markdown.js` into the **Development**
+   tab and **Save changes**.
+3. **Test** tab → set the request URI to `/docs/administration/cluster_snapshot/`
+   and add a header `accept: text/markdown`. Run — confirm the output request
+   URI is `/docs/administration/cluster_snapshot.md`. Then test with
+   `accept: text/html` and confirm the URI is **unchanged**.
+4. **Publish** tab → **Publish function**.
+5. Distribution → **Behaviors** → edit the **Default (\*)** behavior →
+   **Function associations** → **Viewer request** → select
+   `docs-markdown-content-negotiation` → **Save changes**.
+
+> If a viewer-request function is already associated with the behavior, merge
+> this logic into it instead of attaching a second one — a behavior allows only
+> one viewer-request function.
+
+### Apply via CLI
+
+```bash
+DIST_ID=<your-distribution-id>
+
+# Create + publish the function
+aws cloudfront create-function \
+  --name docs-markdown-content-negotiation \
+  --function-config Comment="Serve .md on Accept: text/markdown",Runtime="cloudfront-js-2.0" \
+  --function-code fileb://cloudfront/viewer-request-markdown.js
+
+ETAG=$(aws cloudfront describe-function --name docs-markdown-content-negotiation \
+  --query 'ETag' --output text)
+aws cloudfront publish-function --name docs-markdown-content-negotiation --if-match "$ETAG"
+```
+
+Then associate it with the default behavior. The cleanest way is Console
+(step 5 above). To do it via CLI, `aws cloudfront get-distribution-config`,
+add a `FunctionAssociations` block with `EventType=viewer-request` and the
+function ARN to `DefaultCacheBehavior`, and `update-distribution` with the
+returned `--if-match` ETag.
+
+### Notes
+
+- The function only rewrites page routes (trailing slash) under `/docs/` and
+  `/releasenotes/`, which are exactly the routes with `.md` twins (en only).
+- Because the rewrite happens before the cache lookup, HTML and Markdown cache
+  under separate keys — no cache-key changes needed.
+- **Content-Type:** the deploy workflows already re-upload `.md` files with
+  `Content-Type: text/markdown; charset=utf-8` (a second `aws s3 cp` pass after
+  the main `aws s3 sync`), so S3 serves them as a readable body rather than a
+  download. No manual action needed — just confirm it in the verify step below.
+
+---
+
+## 2. Real 404s — custom error response
+
+**What it fixes:** the `http-status-codes` check (soft 404). Today a request for
+a non-existent page returns **HTTP 200** with page-shell content, so agents try
+to extract information from an error page. We want a real **404**.
+
+Docusaurus already builds a `/404.html`. The goal: when the origin (S3) can't
+find an object, CloudFront serves `/404.html` **with status 404**, not 200.
+
+### Apply via Console
+
+Distribution → **Error pages** → **Create custom error response** (do this for
+**both** 403 and 404 — S3 with Origin Access Control returns **403** for missing
+keys, while the S3 *website* endpoint returns **404**):
+
+| Setting | Value |
+| --- | --- |
+| HTTP error code | `404` (repeat for `403`) |
+| Customize error response | **Yes** |
+| Response page path | `/404.html` |
+| **HTTP Response code** | **`404`** |
+| Error caching minimum TTL | `10` (seconds; tune as desired) |
+
+The critical field is **HTTP Response code = 404**. If an existing rule maps
+403/404 → `/index.html` with response code `200`, that is the soft-404 — change
+its response code to `404` and point it at `/404.html`.
+
+### Apply via CLI
+
+Edit the distribution's `CustomErrorResponses` array (via
+`get-distribution-config` → edit → `update-distribution`) to include:
+
+```json
+{
+  "Quantity": 2,
+  "Items": [
+    { "ErrorCode": 404, "ResponsePagePath": "/404.html", "ResponseCode": "404", "ErrorCachingMinTTL": 10 },
+    { "ErrorCode": 403, "ResponsePagePath": "/404.html", "ResponseCode": "404", "ErrorCachingMinTTL": 10 }
+  ]
+}
+```
+
+> Verify no SPA-style rule remains that rewrites 403/404 to `/index.html` with a
+> `200` response code — that rule is what produces the soft-404.
+
+---
+
+## Verify after deploy
+
+Wait for the distribution to finish deploying (and invalidate `/*` if needed),
+then:
+
+```bash
+# Content negotiation: should return Markdown, not HTML
+curl -sSL -H 'Accept: text/markdown' \
+  https://docs.starrocks.io/docs/administration/cluster_snapshot/ | head -5
+# Expect the "> For the complete documentation index..." blockquote + Markdown.
+
+# Real 404: should be HTTP/2 404, not 200
+curl -sI https://docs.starrocks.io/docs/this-page-does-not-exist/ | head -1
+# Expect: HTTP/2 404
+```
+
+Re-run the afdocs scorecard to confirm `content-negotiation` and
+`http-status-codes` now pass.

--- a/cloudfront/README.md
+++ b/cloudfront/README.md
@@ -69,8 +69,13 @@ returned `--if-match` ETag.
 
 ### Notes
 
-- The function only rewrites page routes (trailing slash) under `/docs/` and
-  `/releasenotes/`, which are exactly the routes with `.md` twins (en only).
+- The function only rewrites page routes (trailing slash) that actually have a
+  `.md` twin: the latest doc version (`/docs/…`, no version prefix) and
+  `/releasenotes/…`. Older versions (`/docs/4.0/`, `/docs/3.5/`, …) and the
+  navigation/index routes excluded in `docusaurus.config.js` are left as HTML,
+  so agents never get a 404 on a missing `.md`. If you change
+  `markdown.excludeRoutes` in the config, update the `EXCLUDED` list in
+  `viewer-request-markdown.js` to match.
 - Because the rewrite happens before the cache lookup, HTML and Markdown cache
   under separate keys — no cache-key changes needed.
 - **Content-Type:** the deploy workflows already re-upload `.md` files with

--- a/cloudfront/viewer-request-markdown.js
+++ b/cloudfront/viewer-request-markdown.js
@@ -12,10 +12,13 @@
 //   /docs/administration/cluster_snapshot.md
 // i.e. "strip the trailing slash, append .md".
 //
-// Only page routes under /docs/ and /releasenotes/ are rewritten — those are
-// the only routes for which the llms-txt plugin generates .md files (en locale
-// only). Requests without text/markdown, asset requests, and localized
-// (/zh/, /ja/) routes are passed through unchanged.
+// Only page routes that actually have a .md twin are rewritten. Markdown is
+// generated for the en locale only, for the latest doc version (served at
+// /docs/ with no version prefix) and all /releasenotes/ pages — and NOT for
+// older versions (/docs/4.0/, /docs/3.5/, ...) or the navigation/index routes
+// excluded in docusaurus.config.js. Everything else — requests without
+// text/markdown, assets, localized (/zh/, /ja/) routes, and docs routes with no
+// .md twin — is passed through unchanged so agents get HTML rather than a 404.
 //
 // Because the URI is rewritten before the cache lookup, the Markdown and HTML
 // responses cache under distinct keys automatically — no need to add the Accept
@@ -41,10 +44,72 @@ function handler(event) {
     return request;
   }
 
-  // Only the en documentation routes that have Markdown twins.
-  if (uri.indexOf('/docs/') === 0 || uri.indexOf('/releasenotes/') === 0) {
+  // Release notes: all pages have Markdown twins.
+  if (uri.indexOf('/releasenotes/') === 0) {
+    request.uri = uri.substring(0, uri.length - 1) + '.md';
+    return request;
+  }
+
+  // Docs: only rewrite when a Markdown twin actually exists. Routes without one
+  // (older versions, navigation/index pages) are left as HTML so agents get a
+  // real page rather than a 404 on a missing .md object.
+  if (uri.indexOf('/docs/') === 0 && docHasMarkdownTwin(uri)) {
     request.uri = uri.substring(0, uri.length - 1) + '.md';
   }
 
   return request;
+}
+
+// Returns true if a /docs/ page route has a generated .md twin.
+//
+// Markdown is generated only for the LATEST version (served at /docs/ with no
+// version prefix) and excludes the navigation/index routes listed in
+// docusaurus.config.js (`markdown.excludeRoutes`). Keep EXCLUDED in sync with
+// that config.
+function docHasMarkdownTwin(uri) {
+  var afterDocs = uri.substring(6); // strip leading "/docs/"
+  var firstSeg = afterDocs.split('/')[0];
+
+  // "/docs/" root itself has no .md twin.
+  if (firstSeg === '') {
+    return false;
+  }
+
+  // Older versions are served at /docs/<major>.<minor>/... and have no .md.
+  // e.g. /docs/4.0/, /docs/3.5/, /docs/2.5/
+  if (/^[0-9]+\.[0-9]+/.test(firstSeg)) {
+    return false;
+  }
+
+  // Navigation-only route trees excluded from Markdown generation.
+  if (
+    uri.indexOf('/docs/category/') === 0 ||
+    uri.indexOf('/docs/cover_pages/') === 0
+  ) {
+    return false;
+  }
+
+  // Specific index/landing pages excluded from Markdown generation.
+  var EXCLUDED = {
+    '/docs/administration/': true,
+    '/docs/administration/management/': true,
+    '/docs/administration/management/configuration/': true,
+    '/docs/benchmarking/': true,
+    '/docs/data_source/catalog/catalog_intro/': true,
+    '/docs/faq/': true,
+    '/docs/integrations/': true,
+    '/docs/integrations/streaming/': true,
+    '/docs/integrations/streaming/apache_kafka/': true,
+    '/docs/introduction/': true,
+    '/docs/loading/': true,
+    '/docs/loading/loading_introduction/loading_overview/': true,
+    '/docs/loading/objectstorage/': true,
+    '/docs/project_help/': true,
+    '/docs/sql-reference/data-types/': true,
+    '/docs/sql-reference/data-types/date-types/': true,
+    '/docs/sql-reference/sql-functions/': true,
+    '/docs/sql-reference/sql-functions/date-time-functions/': true,
+    '/docs/unloading/': true,
+  };
+  return !EXCLUDED[uri];
 }

--- a/cloudfront/viewer-request-markdown.js
+++ b/cloudfront/viewer-request-markdown.js
@@ -1,0 +1,50 @@
+// CloudFront Function (event type: viewer-request)
+// -----------------------------------------------------------------------------
+// Content negotiation for AI agents.
+//
+// When a client requests a documentation page with `Accept: text/markdown`
+// (Claude Code, Cursor, OpenCode, etc. do this), rewrite the request URI to the
+// Markdown twin of the page so CloudFront serves the .md file instead of HTML.
+//
+// The site uses trailingSlash: true, so page routes look like
+//   /docs/administration/cluster_snapshot/
+// and the generated Markdown lives at the sibling key
+//   /docs/administration/cluster_snapshot.md
+// i.e. "strip the trailing slash, append .md".
+//
+// Only page routes under /docs/ and /releasenotes/ are rewritten — those are
+// the only routes for which the llms-txt plugin generates .md files (en locale
+// only). Requests without text/markdown, asset requests, and localized
+// (/zh/, /ja/) routes are passed through unchanged.
+//
+// Because the URI is rewritten before the cache lookup, the Markdown and HTML
+// responses cache under distinct keys automatically — no need to add the Accept
+// header to the cache key.
+//
+// Runtime: cloudfront-js-2.0
+// -----------------------------------------------------------------------------
+
+function handler(event) {
+  var request = event.request;
+
+  var acceptHeader = request.headers.accept;
+  var accept = acceptHeader ? acceptHeader.value : '';
+  if (accept.indexOf('text/markdown') === -1) {
+    return request;
+  }
+
+  var uri = request.uri;
+
+  // Only page routes (trailing slash). Assets have file extensions; .md/.txt
+  // and other files do not end with '/'.
+  if (uri.charAt(uri.length - 1) !== '/') {
+    return request;
+  }
+
+  // Only the en documentation routes that have Markdown twins.
+  if (uri.indexOf('/docs/') === 0 || uri.indexOf('/releasenotes/') === 0) {
+    request.uri = uri.substring(0, uri.length - 1) + '.md';
+  }
+
+  return request;
+}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,7 +51,14 @@ const config = {
       rspackPersistentCache: false, // Speeds up subsequent builds
       swcJsLoader: true, // Uses SWC for faster JS transpilation
       swcJsMinimizer: true, // Uses SWC for faster JS minification
-      swcHtmlMinimizer: true, // Uses SWC for faster HTML minification
+      // SWC HTML minification strips optional closing tags (</td>, </tr>,
+      // </body>, ...). Lenient HTML parsers used by many agent tools — and by
+      // the afdocs markdown-content-parity checker (node-html-parser) — don't
+      // implement HTML5 implicit tag closing, so they fail to nest <body>/<main>/
+      // <table> and fall back to whole-document text, producing false content
+      // mismatches. Docusaurus's default (Terser) minifier keeps closing tags,
+      // so the emitted HTML stays parseable. See scripts/llms-postprocess.js.
+      swcHtmlMinimizer: false,
       lightningCssMinimizer: true, // Uses Lightning CSS for faster CSS minification
       mdxCrossCompilerCache: true, // Speeds up MDX compilation
     },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -149,6 +149,9 @@ const config = {
   ],
   plugins: [
     './src/plugins/tailwind-config.js',
+    // Agent-Friendly Docs: HTML/markdown llms.txt directives + llms.txt splitting.
+    // Only for the default (en) locale — markdown files and llms.txt only exist there.
+    ...(isDefaultLocale ? ['./src/plugins/agent-friendly-docs.js'] : []),
     [
       "@docusaurus/plugin-content-docs",
       {

--- a/scripts/llms-postprocess.js
+++ b/scripts/llms-postprocess.js
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+// llms.txt / markdown post-processing for agent-friendly docs
+// -----------------------------------------------------------------------------
+// Run AFTER `yarn build` completes (see build.sh and the GitHub workflows).
+// It operates on the static build output and does two things:
+//
+//   1. addMarkdownDirective — prepends the spec-recommended blockquote directive
+//      to every generated .md file, pointing agents at /llms.txt.
+//
+//   2. splitLlmsTxt — rewrites the single large llms.txt into a small root index
+//      that links to per-section llms.txt files (progressive disclosure, per
+//      https://agentdocsspec.com/spec/). Sections are split recursively by URL
+//      path so no section file exceeds ~50K characters, while descriptions are
+//      preserved.
+//
+// This lives in a standalone script rather than the agent-friendly-docs plugin's
+// postBuild hook because Docusaurus runs all plugins' postBuild hooks in
+// parallel (Promise.all), so llms.txt (written by the llms-txt plugin) is not
+// guaranteed to exist when the plugin's own hook runs.
+//
+// Usage: node scripts/llms-postprocess.js [buildDir]   (defaults to ./build)
+// -----------------------------------------------------------------------------
+
+const fs = require('fs');
+const path = require('path');
+
+// Must match the Docusaurus `url` (SITE_URL env) so generated links point to
+// the environment being built (prod vs. staging).
+const SITE_URL = (process.env.SITE_URL || 'https://docs.starrocks.io').replace(/\/$/, '');
+const LLMS_TXT_URL = `${SITE_URL}/llms.txt`;
+
+// Keep every section file comfortably under the 50,000-char spec target.
+const MAX_SECTION_BYTES = 45000;
+
+// Sections smaller than this (or with very few links) are inlined directly into
+// the root index as .md links rather than getting their own section file.
+const INLINE_MAX_BYTES = 1500;
+
+// Blockquote prepended to every generated markdown page.
+const MD_DIRECTIVE = `> For the complete documentation index, see [llms.txt](${LLMS_TXT_URL}). This page is also available as Markdown at its \`.md\` URL.`;
+
+function main() {
+  const buildDir = path.resolve(process.argv[2] || 'build');
+  if (!fs.existsSync(buildDir)) {
+    console.error(`[llms-postprocess] build dir not found: ${buildDir}`);
+    process.exit(1);
+  }
+
+  const mdCount = addMarkdownDirective(buildDir);
+  console.log(
+    `[llms-postprocess] Prepended markdown directive to ${mdCount} .md files.`,
+  );
+
+  const result = splitLlmsTxt(buildDir);
+  if (result) {
+    console.log(
+      `[llms-postprocess] Split llms.txt: root index ${result.rootBytes} chars, ` +
+        `${result.fileCount} section files (largest ${result.maxSectionBytes} chars).`,
+    );
+  } else {
+    console.log('[llms-postprocess] No llms.txt found; skipped split.');
+  }
+}
+
+// -----------------------------------------------------------------------------
+// 1. Markdown directive
+// -----------------------------------------------------------------------------
+
+function addMarkdownDirective(buildDir) {
+  let count = 0;
+  for (const file of walk(buildDir, (f) => f.endsWith('.md'))) {
+    const content = fs.readFileSync(file, 'utf8');
+    // Idempotent: skip if the directive is already present near the top.
+    if (content.startsWith('> For the complete documentation index')) continue;
+    fs.writeFileSync(file, `${MD_DIRECTIVE}\n\n${content}`, 'utf8');
+    count++;
+  }
+  return count;
+}
+
+// -----------------------------------------------------------------------------
+// 2. llms.txt splitter
+// -----------------------------------------------------------------------------
+
+function splitLlmsTxt(buildDir) {
+  const rootPath = path.join(buildDir, 'llms.txt');
+  if (!fs.existsSync(rootPath)) return null;
+
+  const raw = fs.readFileSync(rootPath, 'utf8');
+  const { h1, blockquote, sections } = parseLlmsTxt(raw);
+  if (!sections.length) return null;
+
+  const state = { maxSectionBytes: 0, fileCount: 0 };
+  const rootParts = [];
+
+  for (const section of sections) {
+    const entries = section.links
+      .map(parseLink)
+      .filter((e) => e && e.segs.length > 0);
+    if (!entries.length) continue;
+
+    rootParts.push(`## ${section.name}`, '');
+
+    const bytes = renderedBytes(entries);
+    if (bytes <= INLINE_MAX_BYTES || entries.length <= 3) {
+      // Small sections: list their .md links directly in the root index.
+      for (const e of entries) rootParts.push(e.raw);
+    } else {
+      // Larger sections: emit a section file (recursively split) and link to it.
+      const baseSegs = commonPrefix(entries.map((e) => e.segs));
+      const fileUrl = emitNode(buildDir, entries, baseSegs, section.name, state);
+      rootParts.push(
+        `- [${section.name}](${fileUrl}): section index of ${entries.length} documentation pages.`,
+      );
+    }
+    rootParts.push('');
+  }
+
+  const rootBody = [
+    h1 || '# StarRocks Documentation',
+    '',
+    blockquote ||
+      '> StarRocks documentation index for AI agents. Each section links to a section-level llms.txt file or directly to Markdown pages.',
+    '',
+    rootParts.join('\n'),
+  ].join('\n');
+
+  fs.writeFileSync(rootPath, rootBody, 'utf8');
+  return {
+    rootBytes: rootBody.length,
+    fileCount: state.fileCount,
+    maxSectionBytes: state.maxSectionBytes,
+  };
+}
+
+// Recursively emit a section (or sub-section) llms.txt file and return its URL.
+// - entries:  link objects belonging to this node
+// - baseSegs: path segments identifying this node's directory
+//             (e.g. ['docs','sql-reference'])
+// - name:     human-readable name for the node
+function emitNode(buildDir, entries, baseSegs, name, state) {
+  const bytes = renderedBytes(entries);
+  const depth = baseSegs.length;
+
+  // "direct"   = pages living directly at this level (path ends one past base).
+  // "children" = grouped by the next path segment (sub-directories).
+  const direct = [];
+  const groups = new Map();
+  for (const e of entries) {
+    if (e.segs.length <= depth + 1) {
+      direct.push(e);
+    } else {
+      const seg = e.segs[depth];
+      if (!groups.has(seg)) groups.set(seg, []);
+      groups.get(seg).push(e);
+    }
+  }
+
+  const canSplit = groups.size > 0 && depth < 12;
+
+  // Leaf: small enough, or nothing left to split by.
+  if (bytes <= MAX_SECTION_BYTES || !canSplit) {
+    const body = renderSectionFile(name, `## ${name}`, entries.map((e) => e.raw));
+    return writeSectionFile(buildDir, baseSegs, body, state);
+  }
+
+  // Index node: recurse into each child group, plus keep direct pages inline.
+  const lines = [];
+  if (direct.length) {
+    lines.push(`### ${name}`, '');
+    for (const e of direct) lines.push(e.raw);
+    lines.push('');
+  }
+  const childSegs = [...groups.keys()].sort();
+  for (const seg of childSegs) {
+    const childEntries = groups.get(seg);
+    const childName = prettySegment(seg);
+    const childUrl = emitNode(
+      buildDir,
+      childEntries,
+      [...baseSegs, seg],
+      childName,
+      state,
+    );
+    lines.push(
+      `- [${childName}](${childUrl}): ${childEntries.length} documentation pages.`,
+    );
+  }
+
+  const body = renderSectionFile(name, `## ${name}`, lines);
+  return writeSectionFile(buildDir, baseSegs, body, state);
+}
+
+function renderSectionFile(name, heading, contentLines) {
+  return [
+    `# StarRocks Documentation — ${name}`,
+    '',
+    `> Section index of the StarRocks documentation. For the complete documentation index, see [llms.txt](${LLMS_TXT_URL}). Pages are available as Markdown at their \`.md\` URLs.`,
+    '',
+    heading,
+    '',
+    contentLines.join('\n'),
+    '',
+  ].join('\n');
+}
+
+function writeSectionFile(buildDir, baseSegs, body, state) {
+  const fileUrl = `${SITE_URL}/${baseSegs.join('/')}/llms.txt`;
+  const filePath = path.join(buildDir, ...baseSegs, 'llms.txt');
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, body, 'utf8');
+  state.fileCount++;
+  if (body.length > state.maxSectionBytes) state.maxSectionBytes = body.length;
+  return fileUrl;
+}
+
+// -----------------------------------------------------------------------------
+// Parsing / helpers
+// -----------------------------------------------------------------------------
+
+function parseLlmsTxt(raw) {
+  const lines = raw.split('\n');
+  let h1 = '';
+  const blockquoteLines = [];
+  const sections = [];
+  let current = null;
+
+  for (const line of lines) {
+    if (line.startsWith('# ') && !h1) {
+      h1 = line;
+      continue;
+    }
+    if (line.startsWith('## ')) {
+      current = { name: line.slice(3).trim(), links: [] };
+      sections.push(current);
+      continue;
+    }
+    if (current) {
+      if (line.startsWith('- [')) current.links.push(line);
+    } else if (line.startsWith('>')) {
+      blockquoteLines.push(line);
+    }
+  }
+
+  return { h1, blockquote: blockquoteLines.join('\n'), sections };
+}
+
+// Parse a "- [Title](https://...): description" line. Preserves the raw line
+// verbatim; only the URL / path segments are extracted for grouping.
+function parseLink(line) {
+  const m = line.match(/\]\((https?:\/\/[^)]+)\)/);
+  if (!m) return null;
+  const url = m[1];
+  const pathname = url.replace(/^https?:\/\/[^/]+/, '');
+  const segs = pathname.split('/').filter(Boolean);
+  return { raw: line, url, segs };
+}
+
+function renderedBytes(entries) {
+  let n = 0;
+  for (const e of entries) n += e.raw.length + 1;
+  return n;
+}
+
+// Longest common leading path segments across a set of segment arrays.
+function commonPrefix(segArrays) {
+  if (!segArrays.length) return [];
+  // Never treat a trailing file (e.g. "foo.md") as a directory prefix.
+  const prefix = [...segArrays[0]];
+  if (prefix.length && prefix[prefix.length - 1].endsWith('.md')) prefix.pop();
+  for (const segs of segArrays.slice(1)) {
+    let i = 0;
+    while (
+      i < prefix.length &&
+      i < segs.length &&
+      prefix[i] === segs[i] &&
+      !segs[i].endsWith('.md')
+    ) {
+      i++;
+    }
+    prefix.length = i;
+  }
+  // Fall back to the first segment (e.g. "docs") if divergence is total.
+  if (!prefix.length && segArrays[0].length) return [segArrays[0][0]];
+  return prefix;
+}
+
+function prettySegment(seg) {
+  return seg
+    .replace(/\.md$/, '')
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// Recursively yield file paths under dir matching the predicate.
+function* walk(dir, match) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(full, match);
+    } else if (entry.isFile() && match(full)) {
+      yield full;
+    }
+  }
+}
+
+main();

--- a/scripts/llms-postprocess.js
+++ b/scripts/llms-postprocess.js
@@ -72,10 +72,26 @@ function addMarkdownDirective(buildDir) {
     const content = fs.readFileSync(file, 'utf8');
     // Idempotent: skip if the directive is already present near the top.
     if (content.startsWith('> For the complete documentation index')) continue;
-    fs.writeFileSync(file, `${MD_DIRECTIVE}\n\n${content}`, 'utf8');
+    fs.writeFileSync(file, `${MD_DIRECTIVE}\n\n${unescapeIntrawordUnderscores(content)}`, 'utf8');
     count++;
   }
   return count;
+}
+
+// The llms-txt plugin escapes underscores (\_) in prose/headings to avoid
+// accidental Markdown emphasis. For an underscore *between* two word characters
+// (e.g. mv_refresh_total_success_jobs), CommonMark never treats it as emphasis,
+// so the backslash is redundant: rendering is identical with or without it.
+// Removing it keeps identifiers intact for agents reading the raw .md and for
+// tooling that doesn't unescape Markdown before matching. Only intra-word
+// escapes are touched; a leading/standalone \_ (which could be real emphasis)
+// is left alone. Escapes inside code spans/blocks aren't present — Markdown
+// doesn't process escapes there, so the plugin emits raw underscores in code.
+function unescapeIntrawordUnderscores(md) {
+  // Require an alphanumeric on both sides (not just \w, which includes "_"):
+  // this targets identifiers like foo_bar_baz and avoids touching escaped
+  // emphasis runs such as \_\_bold\_\_.
+  return md.replace(/(?<=[A-Za-z0-9])\\_(?=[A-Za-z0-9])/g, '_');
 }
 
 // -----------------------------------------------------------------------------

--- a/scripts/llms-postprocess.js
+++ b/scripts/llms-postprocess.js
@@ -54,8 +54,8 @@ function main() {
   const result = splitLlmsTxt(buildDir);
   if (result) {
     console.log(
-      `[llms-postprocess] Split llms.txt: root index ${result.rootBytes} chars, ` +
-        `${result.fileCount} section files (largest ${result.maxSectionBytes} chars).`,
+      `[llms-postprocess] Split llms.txt: root index ${result.rootBytes} bytes, ` +
+        `${result.fileCount} section files (largest ${result.maxSectionBytes} bytes).`,
     );
   } else {
     console.log('[llms-postprocess] No llms.txt found; skipped split.');
@@ -127,7 +127,7 @@ function splitLlmsTxt(buildDir) {
 
   fs.writeFileSync(rootPath, rootBody, 'utf8');
   return {
-    rootBytes: rootBody.length,
+    rootBytes: byteLen(rootBody),
     fileCount: state.fileCount,
     maxSectionBytes: state.maxSectionBytes,
   };
@@ -210,7 +210,8 @@ function writeSectionFile(buildDir, baseSegs, body, state) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, body, 'utf8');
   state.fileCount++;
-  if (body.length > state.maxSectionBytes) state.maxSectionBytes = body.length;
+  const size = byteLen(body);
+  if (size > state.maxSectionBytes) state.maxSectionBytes = size;
   return fileUrl;
 }
 
@@ -256,9 +257,15 @@ function parseLink(line) {
   return { raw: line, url, segs };
 }
 
+// UTF-8 byte length — the size budgets are in bytes, and docs contain some
+// non-ASCII (curly quotes, etc.), so measure bytes, not UTF-16 char count.
+function byteLen(str) {
+  return Buffer.byteLength(str, 'utf8');
+}
+
 function renderedBytes(entries) {
   let n = 0;
-  for (const e of entries) n += e.raw.length + 1;
+  for (const e of entries) n += byteLen(e.raw) + 1;
   return n;
 }
 

--- a/src/plugins/agent-friendly-docs.js
+++ b/src/plugins/agent-friendly-docs.js
@@ -1,0 +1,70 @@
+// Agent-Friendly Docs plugin
+// -----------------------------------------------------------------------------
+// Improves the site's https://afdocs.dev/ score by making llms.txt / markdown
+// output discoverable to AI agents.
+//
+// This plugin injects a discovery directive into every HTML page:
+//   - a visually-hidden element near the top of the body pointing agents at
+//     /llms.txt and telling them each page is available as Markdown at its
+//     ".md" URL, and
+//   - a <head> alternate link to /llms.txt.
+//
+// The visually-hidden style deliberately avoids `display:none` (which some
+// HTML->markdown converters strip) per the afdocs spec.
+//
+// The related file post-processing (prepending a markdown directive to .md
+// files and splitting llms.txt into a root index + section files) is done by
+// scripts/llms-postprocess.js, which runs AFTER `yarn build` completes.
+// It cannot live in this plugin's postBuild hook because Docusaurus runs all
+// plugins' postBuild hooks in parallel (Promise.all), so llms.txt is not
+// guaranteed to exist yet when this plugin would run.
+//
+// Registered only for the default (en) locale in docusaurus.config.js, matching
+// the llms-txt plugin — the markdown files and llms.txt only exist for en, so
+// the directive is only truthful there.
+// -----------------------------------------------------------------------------
+
+// Visually-hidden style that survives HTML->markdown conversion (avoids
+// display:none, which some converters strip — see the afdocs spec).
+const HIDDEN_STYLE =
+  'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;';
+
+module.exports = function agentFriendlyDocsPlugin(context) {
+  // Match the site URL being built (prod vs. staging) so the directive is
+  // truthful in every environment.
+  const siteUrl = (context.siteConfig.url || 'https://docs.starrocks.io').replace(/\/$/, '');
+  const LLMS_TXT_URL = `${siteUrl}/llms.txt`;
+
+  return {
+    name: 'agent-friendly-docs',
+
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: 'link',
+            attributes: {
+              rel: 'alternate',
+              type: 'text/markdown',
+              href: '/llms.txt',
+              title: 'LLM-friendly documentation index',
+            },
+          },
+        ],
+        preBodyTags: [
+          {
+            tagName: 'div',
+            attributes: {
+              'data-llms-directive': '',
+              style: HIDDEN_STYLE,
+            },
+            innerHTML:
+              `For AI agents: a machine-readable documentation index is available at ` +
+              `<a href="${LLMS_TXT_URL}">${LLMS_TXT_URL}</a>. ` +
+              `Every documentation page is also available as Markdown by appending ".md" to its URL.`,
+          },
+        ],
+      };
+    },
+  };
+};

--- a/src/plugins/agent-friendly-docs.js
+++ b/src/plugins/agent-friendly-docs.js
@@ -56,11 +56,16 @@ module.exports = function agentFriendlyDocsPlugin(context) {
             tagName: 'div',
             attributes: {
               'data-llms-directive': '',
+              // Hidden from assistive tech: this is an agent-facing hint, not
+              // human content. The anchor is kept (agents/detectors look for a
+              // link to llms.txt) but made non-focusable via tabindex="-1" so
+              // keyboard users can't tab to an invisible link.
+              'aria-hidden': 'true',
               style: HIDDEN_STYLE,
             },
             innerHTML:
               `For AI agents: a machine-readable documentation index is available at ` +
-              `<a href="${LLMS_TXT_URL}">${LLMS_TXT_URL}</a>. ` +
+              `<a href="${LLMS_TXT_URL}" tabindex="-1">${LLMS_TXT_URL}</a>. ` +
               `Every documentation page is also available as Markdown by appending ".md" to its URL.`,
           },
         ],


### PR DESCRIPTION
Raises the [afdocs.dev](https://afdocs.dev/) score of docs.starrocks.io (was 71/100) by making the generated `llms.txt` / Markdown output discoverable and appropriately sized for AI agents.

## Build-time fixes (in this repo)

- **HTML directive** — new `src/plugins/agent-friendly-docs.js` (en locale only) injects a visually-hidden directive near the top of `<body>` plus a `<head>` `<link rel="alternate" type="text/markdown">`, both pointing agents at `/llms.txt` and noting `.md` availability. → fixes `llms-txt-directive-html`.
- **Markdown directive** — new `scripts/llms-postprocess.js` prepends a `> ...llms.txt` blockquote to every generated `.md` file (idempotent). → fixes `llms-txt-directive-md`.
- **llms.txt split** — same script rewrites the 203K `llms.txt` into a ~9.5K root index linking to per-section `llms.txt` files (e.g. `/docs/sql-reference/llms.txt`), splitting large sections recursively so every file stays under 50K (largest 39.8K). Descriptions preserved; follows the spec's progressive-disclosure structure. → fixes `llms-txt-size`.
- Post-process runs **after** `yarn build` (Docusaurus runs `postBuild` hooks in parallel, so it can't be a plugin hook) — wired into `build.sh` and both deploy workflows. Honors `SITE_URL` for staging vs prod.
- **Content-Type** — deploy workflows re-upload `.md` files as `text/markdown; charset=utf-8` after the main `aws s3 sync` so content negotiation returns a readable body, not a download.

## Infra deliverables (applied manually in CloudFront — not deployable from CI)

- `cloudfront/viewer-request-markdown.js` — CloudFront Function for content negotiation on `Accept: text/markdown`. → fixes `content-negotiation`.
- `cloudfront/README.md` — apply guide for that function **and** custom error responses to return real 404s instead of soft 404s. → fixes `http-status-codes`.

## Verification

- HTML directive confirmed present in built HTML (fast 2-version build).
- Markdown directive confirmed on real `.md` files; idempotent on re-run.
- Split confirmed on the freshly-built 203K `llms.txt`: root 9.5K, 40 section files, largest 39.8K, zero over 50K.

## Not changed (intentional)

- `llms-txt-coverage` (~15%) — `llms.txt` covers only the current version (4.1) while the sitemap counts all 7 versions; indexing 7 versions would be worse for agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Running the check after building staging with the changes in this PR brings the score from 70 to 91. Some of the low scores will be fixed with the CloudFront changes documented in the cloudfront/README.md.

Interim result:

```bash
https://docs-stage.starrocks.io/ · 7/17/2026, 10:08:10 PM

  Overall Score: 90 / 100 (A)

  Category Scores:
    Content Discoverability              100 / 100 (A+)
    Markdown Availability                 64 / 100 (D)
    Page Size and Truncation Risk         99 / 100 (A)
    Content Structure                    100 / 100 (A+)
    URL Stability and Redirects           36 / 100 (F)
    Observability and Content Health      80 / 100 (B)
    Authentication and Access             99 / 100 (A)
```