### PR TITLE
Build one locale at a time, and fix the feature-card links breaking the daily build

### DIFF
--- a/.github/workflows/prod_deploy_docusaurus.yml
+++ b/.github/workflows/prod_deploy_docusaurus.yml
@@ -62,13 +62,51 @@ jobs:
       - name: Check CloudFront markdown exclusions are in sync
         run: node scripts/check-cloudfront-excludes.js
 
+      # One locale per `yarn build`. Building all three in a single node process
+      # peaks above the runner's heap and gets OOM-killed partway through; a
+      # fresh process per locale stays inside the limit.
+      #
+      # This only works because docusaurus.config.js pins the zh and ja
+      # baseUrls — a single `--locale` disables automatic locale-segment
+      # inference, so without those pins zh and ja land on build/ and wipe the
+      # English site. en must run first: it writes to build/, which Docusaurus
+      # clears before writing.
+      # A failing locale does not stop the loop. The locales break independently
+      # — a broken link in the Japanese translation says nothing about English —
+      # and stopping at the first failure hides the rest, so a red build gets
+      # fixed one locale per day. All failures are reported together at the end
+      # and the step still exits non-zero, so the deploy steps below are skipped.
       - name: Build website
         run:  |
           export NODE_OPTIONS="--max_old_space_size=12288"
           export DOCUSAURUS_PERF_LOGGER=false
           export DOCUSAURUS_IGNORE_SSG_WARNINGS=true
           export BROWSERSLIST_IGNORE_OLD_DATA=true
-          yarn build
+          failed_locales=""
+          for locale in en zh ja; do
+            echo "::group::build ${locale}"
+            if yarn build --locale "${locale}"; then
+              echo "locale ${locale}: OK"
+            else
+              echo "::error::Locale ${locale} failed to build"
+              failed_locales="${failed_locales} ${locale}"
+            fi
+            echo "::endgroup::"
+          done
+          {
+            echo "| locale | result |"
+            echo "| --- | --- |"
+            for locale in en zh ja; do
+              case " ${failed_locales} " in
+                *" ${locale} "*) echo "| ${locale} | ❌ failed |" ;;
+                *)               echo "| ${locale} | ✅ ok |" ;;
+              esac
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${failed_locales}" ]; then
+            echo "Failed locales:${failed_locales}"
+            exit 1
+          fi
 
       - name: Post-process llms.txt and markdown for agents
         run: node scripts/llms-postprocess.js build

--- a/.github/workflows/stage_deploy_docusaurus.yml
+++ b/.github/workflows/stage_deploy_docusaurus.yml
@@ -70,6 +70,20 @@ jobs:
       - name: Check CloudFront markdown exclusions are in sync
         run: node scripts/check-cloudfront-excludes.js
 
+      # One locale per `yarn build`. Building all three in a single node process
+      # peaks above the runner's heap and gets OOM-killed partway through; a
+      # fresh process per locale stays inside the limit.
+      #
+      # This only works because docusaurus.config.js pins the zh and ja
+      # baseUrls — a single `--locale` disables automatic locale-segment
+      # inference, so without those pins zh and ja land on build/ and wipe the
+      # English site. en must run first: it writes to build/, which Docusaurus
+      # clears before writing.
+      #
+      # A failing locale does not stop the loop — the locales break
+      # independently, and stopping at the first failure hides the rest. All
+      # failures are reported together and the step still exits non-zero, so the
+      # deploy steps below are skipped.
       - name: Build website
         run:  |
           export NODE_OPTIONS="--max_old_space_size=12288"
@@ -80,7 +94,31 @@ jobs:
           if [[ $INPUTS_VERSIONS == 'TopTwo' ]]; then
             export BUILD_FAST=true
           fi
-          yarn build
+          failed_locales=""
+          for locale in en zh ja; do
+            echo "::group::build ${locale}"
+            if yarn build --locale "${locale}"; then
+              echo "locale ${locale}: OK"
+            else
+              echo "::error::Locale ${locale} failed to build"
+              failed_locales="${failed_locales} ${locale}"
+            fi
+            echo "::endgroup::"
+          done
+          {
+            echo "| locale | result |"
+            echo "| --- | --- |"
+            for locale in en zh ja; do
+              case " ${failed_locales} " in
+                *" ${locale} "*) echo "| ${locale} | ❌ failed |" ;;
+                *)               echo "| ${locale} | ✅ ok |" ;;
+              esac
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${failed_locales}" ]; then
+            echo "Failed locales:${failed_locales}"
+            exit 1
+          fi
 
       - name: Post-process llms.txt and markdown for agents
         env:

--- a/build.sh
+++ b/build.sh
@@ -10,11 +10,74 @@ export DOCUSAURUS_PERF_LOGGER=false
 # Fails fast if the CloudFront Function's route exclusions have drifted from
 # src/agentDocsRoutes.js.
 node scripts/check-cloudfront-excludes.js
-yarn clear && yarn build
-# Agent-friendly docs: prepend markdown directives + split llms.txt into a
-# root index and per-section files. Must run AFTER the build completes.
-node scripts/llms-postprocess.js build
-# Fails if archived versions flooded the sitemap, which makes agent checkers
-# sampling its head conclude that Accept: text/markdown is ignored.
-node scripts/check-sitemap-markdown-coverage.js build
+
+yarn clear
+
+# One locale per invocation. Building all three in a single `yarn build` peaks
+# above the heap and the process gets OOM-killed partway through; a fresh node
+# process per locale stays inside the limit.
+#
+# This only works because docusaurus.config.js pins the zh and ja baseUrls. A
+# single `--locale` disables automatic locale-segment inference, so without those
+# pins the zh and ja builds land on build/ and wipe the English one. Do not drop
+# them.
+#
+# en must go first: it writes to build/ and Docusaurus clears the output
+# directory before writing, so building it after zh/ja would delete them.
+#
+# A failing locale does NOT stop the run. The locales break independently — a
+# broken link in the Japanese translation says nothing about English — and
+# stopping at the first failure hides the rest, so a red build gets fixed one
+# locale per day. Each locale's failure is recorded and all of them are reported
+# together at the end. Guarding with `if` also keeps `set -e` from aborting here.
+#
+# Plain strings, not arrays: macOS ships bash 3.2, where `${arr[@]}` on an empty
+# array trips `set -u`.
+failed_locales=""
+for locale in en zh ja; do
+  echo "=== building locale: ${locale}"
+  if yarn build --locale "${locale}"; then
+    echo "=== locale ${locale}: OK"
+  else
+    echo "=== locale ${locale}: FAILED"
+    failed_locales="${failed_locales} ${locale}"
+  fi
+done
+
+# build/ now holds all three: English at /, Chinese at /zh/, Japanese at /ja/.
+
+# The post-build steps rewrite and then audit build/, so they are only meaningful
+# once every locale is in place. Skipping them keeps a partial tree from
+# producing a confusing second failure that masks the real one.
+post_build_status="OK"
+if [ -n "${failed_locales}" ]; then
+  post_build_status="SKIPPED (a locale build failed)"
+else
+  # Agent-friendly docs: prepend markdown directives + split llms.txt into a
+  # root index and per-section files. Must run AFTER the build completes.
+  node scripts/llms-postprocess.js build || post_build_status="FAILED (llms-postprocess)"
+  # Fails if archived versions flooded the sitemap, which makes agent checkers
+  # sampling its head conclude that Accept: text/markdown is ignored.
+  if [ "${post_build_status}" = "OK" ]; then
+    node scripts/check-sitemap-markdown-coverage.js build \
+      || post_build_status="FAILED (check-sitemap-markdown-coverage)"
+  fi
+fi
+
+echo
+echo "==================== build summary ===================="
+for locale in en zh ja; do
+  case " ${failed_locales} " in
+    *" ${locale} "*) printf '  %-4s FAILED\n' "${locale}" ;;
+    *)               printf '  %-4s OK\n'     "${locale}" ;;
+  esac
+done
+echo "  post-build  ${post_build_status}"
+echo "======================================================="
+
+if [ -n "${failed_locales}" ] || [ "${post_build_status}" != "OK" ]; then
+  echo "build failed:${failed_locales:- (locales OK)}"
+  exit 1
+fi
+
 yarn serve

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,6 +44,10 @@ const includedVersions = (() => {
 // Archived (non-latest) versions, i.e. the ones that get a /docs/<version>/ prefix.
 const archivedVersions = includedVersions.filter((v) => v !== lastVersion);
 
+// Hoisted so the pinned per-locale baseUrls in `i18n.localeConfigs` below can be
+// derived from it and can't drift out of sync.
+const baseUrl = '/';
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'StarRocks',
@@ -52,7 +56,7 @@ const config = {
 
   url: process.env.SITE_URL || 'https://docs.starrocks.io',
   // Set the /<baseUrl>/ pathname under which your site is served
-  baseUrl: '/',
+  baseUrl: baseUrl,
 
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'StarRocks', // Usually your GitHub org/user name.
@@ -86,6 +90,19 @@ const config = {
     },
   },
 
+  // We build one locale per `docusaurus build` invocation (see build.sh and the
+  // deploy workflows) because building all three in a single node process peaks
+  // above the runner's heap and gets OOM-killed.
+  //
+  // That makes pinning the non-default baseUrls mandatory. Docusaurus normally
+  // infers `<baseUrl><locale>/` for every non-default locale, but passing a
+  // single `--locale` turns the inference off
+  // (isAutomaticBaseUrlLocalizationDisabled: `cliOptions.locale?.length === 1`)
+  // and builds that locale as a standalone site at `/`. The output directory is
+  // derived from the baseUrl (server/site.js: `outDir = build + baseUrl minus
+  // config.baseUrl`), so without these pins the zh and ja builds would land on
+  // build/ and wipe the English site instead of writing build/zh/ and build/ja/.
+  // Do not drop them.
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'zh', 'ja'],
@@ -95,6 +112,10 @@ const config = {
       },
       zh: {
         htmlLang: 'zh-CN',
+        baseUrl: `${baseUrl}zh/`,
+      },
+      ja: {
+        baseUrl: `${baseUrl}ja/`,
       },
     },
   },

--- a/src/components/Features/index.js
+++ b/src/components/Features/index.js
@@ -3,11 +3,79 @@ import Heading from '@theme/Heading';
 import styles from './styles.module.css';
 import React from 'react';
 import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import {useDocsVersion} from '@docusaurus/plugin-content-docs/client';
+
+// The feature cards on StarRocks_intro point at the same eleven destinations in
+// every language, so the URLs live here once and the per-language lists below
+// carry only the text. They used to be repeated in all three lists, which is how
+// four of them silently rotted: the targets were restructured upstream and only
+// the daily full build noticed.
+//
+// Paths are relative to a version's docs root (no leading slash) and are turned
+// into absolute URLs by useFeatureUrl() below. Do NOT write them as `../../foo/`
+// — a relative URL resolves against the *page* URL, and StarRocks_intro sits at a
+// different depth depending on the version (`introduction/StarRocks_intro` in
+// 3.1-3.4, the version root in 3.5+) and on whether the version is the unprefixed
+// latest one. That is what made 3.5 and 4.0 link into the 4.1 docs.
+// Several of these resolve to a bare directory because the doc inside is a
+// Docusaurus "category index": a file named index.*, readme.*, or after its own
+// parent directory (plugin-content-docs/lib/docs.js, isCategoryIndex) takes the
+// directory's slug rather than its own. That is why the target is
+// `loading/loading_introduction/` and not
+// `loading/loading_introduction/loading_introduction/`.
+const DOC_PATHS = {
+  introduction: 'introduction/',
+  quickStart: 'quick_start/',
+  loading: 'loading/loading_introduction/',
+  tableDesign: 'table_design/StarRocks_table_design/',
+  dataLakes: 'integrations/data_lakes/',
+  semiStructured: 'sql-reference/data-types/semi_structured/',
+  integrations: 'integrations/',
+  administration: 'administration/',
+  reference: 'sql-reference/',
+  faq: 'faq/',
+  benchmarking: 'benchmarking/',
+};
+
+// 3.4 and older predate the upstream docs restructure. There, data loading and
+// the data lake page still live under their old names, and "Semi-structured" and
+// "Reference" are `link: {type: generated-index}` categories rather than real
+// docs, so they are served from /category/. Those categories are gone from 3.5
+// onward (0 generated-index categories remain), replaced by index docs.
+const LEGACY_DOC_PATHS = {
+  ...DOC_PATHS,
+  loading: 'loading/Loading_intro/',
+  dataLakes: 'data_source/data_lakes/',
+  semiStructured: 'category/semi-structured/',
+  reference: 'category/reference/',
+};
+
+// Versions before 3.5 use the pre-restructure layout. Anything unparseable
+// (`current`, used when DISABLE_VERSIONING is set) tracks main, which is current.
+function usesLegacyPaths(version) {
+  const match = /^(\d+)\.(\d+)$/.exec(version);
+  if (!match) {
+    return false;
+  }
+  const [, major, minor] = match;
+  return Number(major) * 100 + Number(minor) < 305;
+}
+
+// Resolve a DOC_PATHS key to an absolute URL for the version being rendered.
+// The latest version is served unprefixed at /docs/, every other version at
+// /docs/<version>/. useBaseUrl prepends the locale baseUrl, so this stays correct
+// for the zh (/zh/) and ja (/ja/) builds.
+function useFeatureUrl(slot) {
+  const {version, isLast} = useDocsVersion();
+  const paths = usesLegacyPaths(version) ? LEGACY_DOC_PATHS : DOC_PATHS;
+  return useBaseUrl(`/docs/${isLast ? '' : `${version}/`}${paths[slot]}`);
+}
 
 const ChineseFeatureList = [
   {
     title: '产品简介',
-    url: '../../introduction/',
+    slot: 'introduction',
     description: (
       <>
         OLAP、特性、系统架构
@@ -16,7 +84,7 @@ const ChineseFeatureList = [
   },
   {
     title: '快速入门信息',
-    url: '../../quick_start/',
+    slot: 'quickStart',
     description: (
       <>
         快速部署、导入、查询
@@ -25,7 +93,7 @@ const ChineseFeatureList = [
   },
   {
     title: '导入数据',
-    url: '../../loading/Loading_intro/',
+    slot: 'loading',
     description: (
       <>
         数据清洗、转换、导入
@@ -34,7 +102,7 @@ const ChineseFeatureList = [
   },
   {
     title: '表设计',
-    url: '../../table_design/StarRocks_table_design/',
+    slot: 'tableDesign',
     description: (
       <>
         表、索引、分区、加速
@@ -43,7 +111,7 @@ const ChineseFeatureList = [
   },
   {
     title: '查询数据湖',
-    url: '../../data_source/data_lakes/',
+    slot: 'dataLakes',
     description: (
       <>
         Iceberg, Hive, Delta Lake, …
@@ -52,7 +120,7 @@ const ChineseFeatureList = [
   },
   {
     title: '半结构化类型',
-    url: '../../category/semi-structured/',
+    slot: 'semiStructured',
     description: (
       <>
         JSON, map, struct, array
@@ -61,7 +129,7 @@ const ChineseFeatureList = [
   },
   {
     title: '外部系统集成',
-    url: '../../integrations/',
+    slot: 'integrations',
     description: (
       <>
         BI、IDE、认证信息
@@ -70,7 +138,7 @@ const ChineseFeatureList = [
   },
   {
     title: '管理手册',
-    url: '../../administration/',
+    slot: 'administration',
     description: (
       <>
         扩缩容、备份恢复、权限、性能调优
@@ -79,7 +147,7 @@ const ChineseFeatureList = [
   },
   {
     title: '参考手册',
-    url: '../../category/reference/',
+    slot: 'reference',
     description: (
       <>
         SQL 语法、命令、函数、变量
@@ -88,7 +156,7 @@ const ChineseFeatureList = [
   },
   {
     title: '常见问题解答',
-    url: '../../faq/',
+    slot: 'faq',
     description: (
       <>
         部署、导入、查询、权限常见问题
@@ -97,7 +165,7 @@ const ChineseFeatureList = [
   },
   {
     title: '性能测试',
-    url: '../../benchmarking/',
+    slot: 'benchmarking',
     description: (
       <>
         性能测试：数据库性能对比
@@ -109,7 +177,7 @@ const ChineseFeatureList = [
 const EnglishFeatureList = [
   {
     title: 'Introduction',
-    url: '../../introduction/',
+    slot: 'introduction',
     description: (
       <>
         OLAP, features, architecture
@@ -118,7 +186,7 @@ const EnglishFeatureList = [
   },
   {
     title: 'Quick Start',
-    url: '../../quick_start/',
+    slot: 'quickStart',
     description: (
       <>
         Get up and running quickly.
@@ -127,7 +195,7 @@ const EnglishFeatureList = [
   },
   {
     title: 'Data Loading',
-    url: '../../loading/Loading_intro/',
+    slot: 'loading',
     description: (
       <>
         Clean, transform, and load
@@ -136,7 +204,7 @@ const EnglishFeatureList = [
   },
   {
     title: 'Table Design',
-    url: '../../table_design/StarRocks_table_design/',
+    slot: 'tableDesign',
     description: (
       <>
         Tables, indexing, acceleration
@@ -145,7 +213,7 @@ const EnglishFeatureList = [
   },
   {
     title: 'Data Lakes',
-    url: '../../data_source/data_lakes/',
+    slot: 'dataLakes',
     description: (
       <>
         Iceberg, Hive, Delta Lake, …
@@ -154,7 +222,7 @@ const EnglishFeatureList = [
   },
   {
     title: 'Work with semi-structured data',
-    url: '../../category/semi-structured/',
+    slot: 'semiStructured',
     description: (
       <>
         JSON, map, struct, array
@@ -163,7 +231,7 @@ const EnglishFeatureList = [
   },
   {
     title: 'Integrations',
-    url: '../../integrations/',
+    slot: 'integrations',
     description: (
       <>
         BI tools, IDEs, Cloud authentication, …
@@ -172,7 +240,7 @@ const EnglishFeatureList = [
   },
   {
     title: 'Administration',
-    url: '../../administration/',
+    slot: 'administration',
     description: (
       <>
         Scale, backups, roles and privileges, …
@@ -181,7 +249,7 @@ const EnglishFeatureList = [
   },
   {
     title: 'Reference',
-    url: '../../category/reference/',
+    slot: 'reference',
     description: (
       <>
         SQL, functions, error codes, …
@@ -190,7 +258,7 @@ const EnglishFeatureList = [
   },
   {
     title: 'FAQs',
-    url: '../../faq/',
+    slot: 'faq',
     description: (
       <>
         Frequently asked questions.
@@ -199,7 +267,7 @@ const EnglishFeatureList = [
   },
   {
     title: 'Benchmarks',
-    url: '../../benchmarking/',
+    slot: 'benchmarking',
     description: (
       <>
         DB performance comparison benchmarks.
@@ -211,7 +279,7 @@ const EnglishFeatureList = [
 const JapaneseFeatureList = [
   {
     title: '紹介',
-    url: '../../introduction/',
+    slot: 'introduction',
     description: (
       <>
         OLAP、機能、アーキテクチャ
@@ -220,7 +288,7 @@ const JapaneseFeatureList = [
   },
   {
     title: 'クイックスタート',
-    url: '../../quick_start/',
+    slot: 'quickStart',
     description: (
       <>
         デプロイ、ロード、クエリ
@@ -229,7 +297,7 @@ const JapaneseFeatureList = [
   },
   {
     title: 'データロード',
-    url: '../../loading/Loading_intro/',
+    slot: 'loading',
     description: (
       <>
         データクレンジング、変換、ロード
@@ -238,7 +306,7 @@ const JapaneseFeatureList = [
   },
   {
     title: 'テーブルデザイン',
-    url: '../../table_design/StarRocks_table_design/',
+    slot: 'tableDesign',
     description: (
       <>
         テーブル、インデックス、パーティション、クエリー加速
@@ -247,7 +315,7 @@ const JapaneseFeatureList = [
   },
   {
     title: 'データレイクをクエリ',
-    url: '../../data_source/data_lakes/',
+    slot: 'dataLakes',
     description: (
       <>
         Iceberg、Hive、Delta Lake …
@@ -256,7 +324,7 @@ const JapaneseFeatureList = [
   },
   {
     title: 'セミ構造化タイプ',
-    url: '../../category/semi-structured/',
+    slot: 'semiStructured',
     description: (
       <>
         JSON、map、struct、array
@@ -265,7 +333,7 @@ const JapaneseFeatureList = [
   },
   {
     title: '外部システム統合',
-    url: '../../integrations/',
+    slot: 'integrations',
     description: (
       <>
         BI、IDE、認証情報
@@ -274,7 +342,7 @@ const JapaneseFeatureList = [
   },
   {
     title: '管理',
-    url: '../../administration/',
+    slot: 'administration',
     description: (
       <>
         スケールインとスケールアウト、バックアップ、権限、パフォーマンスチューニング
@@ -283,7 +351,7 @@ const JapaneseFeatureList = [
   },
   {
     title: 'リファレンス',
-    url: '../../category/reference/',
+    slot: 'reference',
     description: (
       <>
         SQL 構文、コマンド、関数、変数
@@ -292,7 +360,7 @@ const JapaneseFeatureList = [
   },
   {
     title: 'FAQ',
-    url: '../../faq/',
+    slot: 'faq',
     description: (
       <>
         デプロイ、ロード、クエリー、権限 FAQ
@@ -301,7 +369,7 @@ const JapaneseFeatureList = [
   },
   {
     title: 'ベンチマーク',
-    url: '../../benchmarking/',
+    slot: 'benchmarking',
     description: (
       <>
         ベンチマーク：データベース・パフォーマンスの比較
@@ -310,10 +378,11 @@ const JapaneseFeatureList = [
   },
 ];
 
-function Feature({url, title, description}) {
+function Feature({slot, title, description}) {
+  const url = useFeatureUrl(slot);
   return (
     <div className={clsx('col col--6 margin-bottom--lg')}>
-     <Link href={url} target="_self" className="card padding--lg cardContainer_fWXF">
+     <Link to={url} target="_self" className="card padding--lg cardContainer_fWXF">
       <div className="text--center padding-horiz--md">
         <Heading as="h3">{title}</Heading>
         <p>{description}</p>


### PR DESCRIPTION
Two changes. The first is the OOM work; the second is the fix for the currently-red daily build, found while verifying it.

## Build one locale at a time

Building `en`, `zh` and `ja` in a single `yarn build` peaks above the heap and gets OOM-killed partway through. `build.sh` and both deploy workflows now run a fresh node process per locale.

This **requires** the pinned baseUrls in `docusaurus.config.js`. Passing a single `--locale` disables automatic locale-segment inference (`isAutomaticBaseUrlLocalizationDisabled: cliOptions.locale?.length === 1`), and the output directory is derived from the baseUrl (`server/site.js`: `outDir = build + baseUrl minus config.baseUrl`). Without the pins, `zh` and `ja` build as standalone sites at `/` and land on `build/`, wiping the English site. `en` runs first because it writes to `build/`, which Docusaurus clears before writing.

Verified against Docusaurus's own loaders with the single-`--locale` code path:

```
en   baseUrl=/       -> outDir=build/
zh   baseUrl=/zh/    -> outDir=build/zh/
ja   baseUrl=/ja/    -> outDir=build/ja/
```

All three then built locally and coexisted — `build/` (en, with `llms.txt` and both sitemaps intact), `build/zh` (740M), `build/ja` (812M) — followed by `llms-postprocess.js` (1124 files, 19 sections) and `check-sitemap-markdown-coverage.js` (100/100 twins).

### Failures no longer stop the run

The locales break independently, and stopping at the first failure hides the rest — the Aug 13 daily build failed on `en` and never revealed that the Japanese translation was broken too. Failures are now collected and reported together:

```
==================== build summary ====================
  en   OK
  zh   OK
  ja   FAILED
  post-build  SKIPPED (a locale build failed)
=======================================================
```

The workflows do the same with `::error::` annotations and a step-summary table. The step still exits non-zero, so the S3 sync and CloudFront invalidation are skipped as before. Post-build scripts are gated on every locale succeeding, since they rewrite and then audit `build/` and would otherwise throw a confusing second error against a partial tree.

Tested against stubbed builds: clean run, one locale failing, two failing, and each post-build script failing.

## Fix the feature-card links

`StarRocks_intro` renders `src/components/Features`, whose card URLs were hardcoded and duplicated across the Chinese, English and Japanese lists. Four broke when the upstream docs were restructured and the change was backported to `branch-3.5` and `branch-4.0`:

| was | now |
| --- | --- |
| `loading/Loading_intro/` | `loading/loading_introduction/` |
| `data_source/data_lakes/` | `integrations/data_lakes/` |
| `category/semi-structured/` | `sql-reference/data-types/semi_structured/` |
| `category/reference/` | `sql-reference/` |

Several resolve to a bare directory because the doc inside is a *category index* — a file named `index.*`, `readme.*`, or after its own parent directory takes the directory's slug (`plugin-content-docs/lib/docs.js`, `isCategoryIndex`).

3.1–3.4 still use the pre-restructure layout, where Semi-structured and Reference are `generated-index` categories served from `/category/`, so they keep the old paths via `LEGACY_DOC_PATHS`. 3.5/4.0/4.1 are uniformly the new layout across all three locales.

The relative form was **also silently wrong**. `../../` resolves against the page URL, and `StarRocks_intro` sits at a different depth per version (`introduction/StarRocks_intro` in 3.1–3.4, the version root in 3.5+), so on 3.5 and 4.0 it resolved to `/docs/` and sent readers into the 4.1 docs — never reported, because the link wasn't broken. URLs now come from `useDocsVersion()` + `useBaseUrl()`. Rendered output:

| version | target |
| --- | --- |
| 4.1 (latest, unprefixed) | `/zh/docs/loading/loading_introduction/` |
| 3.5 (prefixed) | `/zh/docs/3.5/loading/loading_introduction/` |
| 3.4 (legacy) | `/zh/docs/3.4/category/reference/` |

### Why PR checks never caught this

`ci-doc-checker.yml` in `StarRocks/starrocks` runs lychee over `docs/**/*.md` only — a `.js` file is out of scope — and its `docusaurus-build` job builds *that* repo's `docs/docusaurus/` tree with its own `src/`, never this repo's. It also sets `DISABLE_VERSIONING: true` and drops `ja` entirely. Nothing in the PR pipeline renders this component.

## Not fixed here

`docs/ja/loading/spark/Spark-connector-starrocks.md:537` has `../../Load_to_Primary_Key_tables.md`, which overshoots to a file that does not exist. `main` is already correct (`../../loading/...`); the backports conflicted and auto-closed, so `branch-3.5`, `branch-4.0` and `branch-4.1` still carry it. Being fixed separately upstream — until then the daily build will fail on `ja` rather than `en`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)